### PR TITLE
docs: make SentiStream the repository entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,40 @@
-# PLStream: A Framework for Fast Polarity Labelling of Massive Data Streams
+# SentiStream
 
-## Motivation
-* When dataset freshness is critical, the annotating of high speed unlabelled data streams becomes critical but remains an open problem.
-* We propose PLStream, a novel Apache Flink-based framework for fast polarity labelling of massive data streams, like Twitter tweets or online product reviews.
+SentiStream is a co-training framework for adaptive online sentiment analysis
+over continuously evolving data streams. This DataSys repository preserves the
+paper artifact together with the earlier PLStream labeling pipeline used by the
+project.
 
-## Environment Requirements
-relative python packages are summerized in `requirements.txt`
-1. Python 3.7
-2. Java 8
-3. Redis server v7.0.0
+## Repository layout
 
-## DataSource
-* Dataset quick access in https://course.fast.ai/datasets#nlp
-### Tweets
-* 1.6 million labeled Tweets:
-* Source:[Sentiment140](http://cs.stanford.edu/people/alecmgo/trainingandtestdata.zip)
-### Yelp Reviews
-* 280,000 training and 19,000 test samples in each polarity
-* Source:[Yelp Review Polarity](https://s3.amazonaws.com/fast-ai-nlp/yelp_review_polarity_csv.tgz)
-### Amazon Reviews
-* 1,800,000 training and 200,000 testing samples in each polarity
-* Source:[Amazon product review polarity](https://s3.amazonaws.com/fast-ai-nlp/amazon_review_polarity_csv.tgz)
+- [`SentiStream/`](SentiStream/) contains the SentiStream implementation,
+  datasets, experiment scripts, and detailed setup instructions.
+- [`PLStream/`](PLStream/) contains the earlier Apache Flink and Redis polarity
+  labeling pipeline.
 
-## Quick Start
-quick try PLStream on yelp review dataset
-### Data Prepare
-```
-cd PLStream
-wget https://s3.amazonaws.com/fast-ai-nlp/yelp_review_polarity_csv.tgz
-tar zxvf yelp_review_polarity_csv.tgz
-mv yelp_review_polarity_csv/train.csv train.csv
-```
-### 1. Install required environment of PLStream
-```
-pip install -r requirements.txt
-```
-### 2. Start Redis-Server in a terminal
-```
-redis-server
-```
-### 3. Run PLStream
-```
-python PLStream.py
-```
-* The outputs' form is "original text" + "label" + "@@@@":
-* With help of a split("@@@@") function we can further reorganize the labelled dataset.
+## Publication
 
-### Optional
-to see the labelling accuracy, simply run:
-`python PLStream_acc.py`
+Yuhao Wu, Karthick Sharma, Chun Wei Seah, and Shuhao Zhang. "SentiStream: A
+Co-Training Framework for Adaptive Online Sentiment Analysis in Evolving Data
+Streams." *Proceedings of the 2023 Conference on Empirical Methods in Natural
+Language Processing*, pages 6198-6212, 2023.
+
+- Paper: https://doi.org/10.18653/v1/2023.emnlp-main.380
+- Canonical repository: https://github.com/DataSysResearch/SentiStream
+
+```bibtex
+@inproceedings{wu-etal-2023-sentistream,
+  title = {{SentiStream}: A Co-Training Framework for Adaptive Online Sentiment Analysis in Evolving Data Streams},
+  author = {Wu, Yuhao and Sharma, Karthick and Seah, Chun Wei and Zhang, Shuhao},
+  booktitle = {Proceedings of the 2023 Conference on Empirical Methods in Natural Language Processing},
+  year = {2023},
+  pages = {6198--6212},
+  doi = {10.18653/v1/2023.emnlp-main.380},
+  url = {https://aclanthology.org/2023.emnlp-main.380}
+}
+```
+
+## Project status
+
+This is a research artifact maintained for reproducibility. Start with the
+component README that matches the experiment you intend to run.


### PR DESCRIPTION
Cross-checks the personal publication list against the project README and organization publication pages. Adds primary DOI/OpenReview evidence, corrects authorship and canonical links, and keeps author-reported acceptances explicitly qualified.